### PR TITLE
mabla - new definition

### DIFF
--- a/gismu/m/mabla.yaml
+++ b/gismu/m/mabla.yaml
@@ -1,7 +1,6 @@
 Word: mabla
 Rafsi: mal
-Definition: x1 is a derogative connotation/sense of x2 used by x3; x3 derogates/'curses
-  at' x2 in form x1.
+Definition: x1 is execrable/deplorable/wretched/shitty/awful/rotten/miserable/contemptible/crappy/inferior/low-quality in property x2 by standard x3; x1 stinks/sucks in aspect x2 according to x3.
 Notes: Bloody (British sense), fucking, shit, goddamn.  See also {palci}, {dapma},
   {xlali}, {zabna}, {funca}, {ganti}, {ganxo}, {gletu}, {gutra}, {kalci}, {pinca},
   {pinji}, {plibu}, {vibna}, {vlagi}, {zargu}.


### PR DESCRIPTION
This definition is more useful and matches `mabla`s usage. Also, Robin has already announced `mabla` and `zabna`'s new definitions official by fiat on the BPFK list[1](https://groups.google.com/forum/#!topic/bpfk-list/rqMLDfmGBWk) once, so this seems a mere formality.

Proposed definition: 
x1 is execrable/deplorable/wretched/shitty/awful/rotten/miserable/contemptible/crappy/inferior/low-quality in property x2 by standard x3; x1 stinks/sucks in aspect x2 according to x3.
