### PR TITLE
under conditions

### DIFF
--- a/global/under conditions
+++ b/global/under conditions
@@ -1,0 +1,1 @@
+Remove "under conditions" places throughout the gimste. The places are so rarely needed and are never central to the definition, since a condition can alwayws be added to anything. When a condition needs to be specified, {va'o} can be used.


### PR DESCRIPTION
Remove "under conditions" places throughout the gimste. The places are so rarely needed and are never central to the definition, since a condition can always be added to anything. When a condition needs to be specified, {va'o} can be used.
