### PR TITLE
remove tirxu3

### DIFF
--- a/gismu/t/tirxu.yaml
+++ b/gismu/t/tirxu.yaml
@@ -4,8 +4,7 @@ rafsi:
 examples: No examples.
 definitions:
   en:
-    place structure: x1 is a tiger/leopard/jaguar/[tigress] of species/breed x2 with
-      coat markings x3.
+    place structure: x1 is a tiger/leopard/jaguar/[tigress] of species/breed x2.
     notes:
     - 'A great cat noted/recognized by its markings, metaphorically: stripes, tiger
       markings.  See also {mlatu}.'


### PR DESCRIPTION
New definition:
x1 is a tiger/leopard/jaguar/[tigress] of species/breed x2

I don't know what to do about the notes. Currently they read "'A great cat noted/recognized by its markings, metaphorically: stripes, tiger markings.  See also {mlatu}.'"

This should probably adjusted as well.
