### PR TITLE
general style question about definitions

### DIFF
--- a/global/general style question about any definitions
+++ b/global/general style question about any definitions
@@ -1,0 +1,3 @@
+Should the definitions include sumti types? Should they be phrased "x1 (li)" or "x1 (number)", "x2 (ka)" or "x2 (property)", etc?
+Either way, it should be consistent. 
+And what all those gismu that used to be used with {nu}, but are now more commonly used with {ka}?


### PR DESCRIPTION
Should the definitions include sumti types? Should they be phrased "x1 (li)..." or "x1 (number)", "x2 (ka)" or "x2 (property)", etc?
Either way, it should be consistent. 
And what all those gismu that used to be used with {nu}, but are now more commonly used with {ka}?
