### PR TITLE
Swap bongu2 and bongu3

### DIFF
--- a/gismu/b/bongu.yaml
+++ b/gismu/b/bongu.yaml
@@ -5,10 +5,10 @@ rafsi:
 examples: No examples.
 definitions:
   en:
-    place structure: 'x1 is a/the bone/ivory [body-part], performing function x2 in
-      body of x3; [metaphor: calcium].'
+    place structure: 'x1 is a/the bone/ivory [body-part] of body/species x2 performing 
+    function x3; [metaphor: calcium].'
     notes:
-    - 'x2 is likely an abstract: may be structure/support for some body part, but
+    - 'x3 is likely an abstract: may be structure/support for some body part, but
       others as well such as the eardrum bones; the former can be expressed as (tu''a
       le <body-part>); cartilage/gristle (= {ranbo''u}), skeleton (= {bogygreku}).  See
       also {greku}, {denci}, {jirna}, {sarji}.'


### PR DESCRIPTION
{bongu} doesn't comply to the body part gismu family's argument structure: x1: body part, x2: body/individual (+ possibly a function argument x3)
{bongu} should parallels {rango}'s argument structure, and this is the way {bongu} is usually used, as evidenced by the results retrieved by korpora zei sisku:

• bongu-2: https://www.alexburka.com/~danr/#?stats_reduce=word&cqp=[tags%20_%3D%20%22bongu2%22]&search_tab=1&hpp=100&search=cqp
• bongu-3: https://www.alexburka.com/~danr/#?stats_reduce=word&cqp=[tags%20_%3D%20%22bongu3%22]&search_tab=1&hpp=100&search=cqp

As you can see, there is five hits for bongu2 used as a body, and three hits for bongu3 used for the same purpose.
