### PR TITLE
skari: remove x4 and clarify x2

### DIFF
--- a/gismu/s/skari.yaml
+++ b/gismu/s/skari.yaml
@@ -4,10 +4,9 @@ rafsi:
 examples: No examples.
 definitions:
   en:
-    place structure: x1 is/appears to be of color/hue x2 as perceived/seen by x3 under
-      conditions x4.
+    place structure: x1 is/appears to be of color/hue x2 as perceived/seen by x3.
     notes:
-    - Conditions may include lighting, background, etc..  See also {blanu}, {bunre},
+    - See also {blanu}, {bunre},
       {cicna}, {cinta}, {crino}, {grusi}, {narju}, {nukni}, {pelxu}, {xunre}, {zirpu},
       {carmi}, {kandi}, {xekri}, {blabi}.
     glosses:


### PR DESCRIPTION
Proposed definition without x4:

skari: x1 is/appears to be of color/hue x2 as perceived/seen by x3.

skari2 is one of those places I was never comfortable with. I've seen it used with ka, as in {ta skari lo ka xunre}. I'm not too happy with that, or will colors and measurements. 

I wish we could actually talk about colors and not just things that have those colors. Then skari would serve as an interface between objects and colors.

If, for instance, there existed a brivla {broda} "x1 is the color red", then {ta skari lo broda} is perfect for "That thing has the color red." whilie we can still speak generally about colors {mi nelci lo broda} "I like the color red." ({.i na'i mi nelci lo xunre}), which has nothing to do with liking red things. I can like the color red, but hate that my wall is red. I can like red, but hate all red things on the planet.

But we do not have such color brivla, nor do we have words for abstract measurements, like "a meter", or "a second", or "a dollar". No dimensioned numbers either. We are always forced to introduce stand-in events even when we don't want to. I wish we had more options.
