### PR TITLE
Remove "complete specifications"

### DIFF
--- a/global/remove "complete specifications"
+++ b/global/remove "complete specifications"
@@ -1,0 +1,3 @@
+Some gismu definitions explicitly ask for so-called "complete sets" or "complete masses" in some sumti places. Get rid of them and allow incomplete specifications everywhere.
+
+See also: http://www.lojban.org/tiki/BPFK+gismu+Section%3A+Complete+vs.+Incomplete+Specifications


### PR DESCRIPTION
Some gismu definitions explicitly ask for so-called "complete sets" or "complete masses" in some sumti places. Get rid of them and allow incomplete specifications everywhere.

See also: http://www.lojban.org/tiki/BPFK+gismu+Section%3A+Complete+vs.+Incomplete+Specifications
