### PR TITLE
by standard / in aspect

### DIFF
--- a/by-standard and in-aspect
+++ b/by-standard and in-aspect
@@ -1,0 +1,11 @@
+A lot of the "by standard" places should be removed, but a lot of them should be turned into "in aspect" places instead. I'm thinking of things like xamgu3. 
+
+In the balningau thread, xorxes listed a bunch of gismu that have "aspects" (sometimes simply called "property") :
+"zo mansa .e zo vajni .e zo cfipu .e zo cizra .e zo xajmi .e zo
+fange .e zo zdile .e zo trina .e zo .melbi .e zo cnino .e zo slabu .e zo
+dicra .e zo zunti cu mintu fi lo ka tersu'i stura .i ku'i ki'u ma zo
+cinri .e zo misno .e zo dirba .e zo ckape .e so'o drata na go'i "
+
+Indeed, why don't {cinri}, {misno}, {dirba}, {ckape} and other such words don't have the same kind of "in aspect" places? 
+
+I would prefer them to match.


### PR DESCRIPTION
A lot of the "by standard" places should be removed, but a lot of them should be turned into "in aspect" places instead. I'm thinking of things like xamgu3. 

In the balningau thread, xorxes listed a bunch of gismu that have "aspects" (sometimes simply called "property") :
"zo mansa .e zo vajni .e zo cfipu .e zo cizra .e zo xajmi .e zo
fange .e zo zdile .e zo trina .e zo .melbi .e zo cnino .e zo slabu .e zo
dicra .e zo zunti cu mintu fi lo ka tersu'i stura .i ku'i ki'u ma zo
cinri .e zo misno .e zo dirba .e zo ckape .e so'o drata na go'i "

Indeed, why don't words like {cinri}, {misno}, {dirba}, {ckape} have the same kind of "in aspect" places? I would much prefer that.
