### PR TITLE
suksa with ka

### DIFF
--- a/gismu/s/suksa.yaml
+++ b/gismu/s/suksa.yaml
@@ -1,11 +1,10 @@
 word: suksa
 rafsi:
 - suk
-examples: No examples.
+examples: lo mlatu cu suksa lo ka canci
 definitions:
   en:
-    place structure: x1 (event/state) is sudden/sharply changes at stage/point x2
-      in process/property/function x3.
+    place structure: x1 is-sudden-in/suddenly-does x2 (ka)".
     notes:
     - Also abrupt, discontinuous.  See also {spaji}, {vitci}, {vlile}.
     glosses:


### PR DESCRIPTION
xorxes suggested the following place structure for {suksa}:

x1 is-sudden-in/suddenly-does x2 (ka)".
e.g. "lo mlatu cu suksa lo ka canci"

I checked the corpus, and it would break no usage. It's quite compatible with the old definition, too.
Actually, in my Oz translation, I used {suksa} as "x1 occurs suddenly" and often had to use {jai suksa fai lo ka} to achieve what the new definition would accomplish automatically.
