### PR TITLE
grammar words

### DIFF
--- a/global/grammar words
+++ b/global/grammar words
@@ -1,0 +1,23 @@
+This group consists of:
+gadri
+gismu 
+valsi
+sumti
+cmavo
+lujvo
+tanru
+bridi
+gerna
+(+ others?)
+
+xorxes recently said:
+<quote>
+I'm not advocating these by any means, I think grammar words are particularly messy and could do with some unbloating, but this is how I read the current definitions:
+zo nelci cu gismu lo ka ce'u ce'u nelci kei lo nelci ce'o lo se nelci zoi ke nel ke jo'u zoi ke nei ke jo'u zoi ke nelcy ke jo'u zoi ke nelci ke
+
+lo'u mutce nelci le'u cu tanru zo mutce zo nelci lo ka ce'u xi pa mutce lo ka ce'u xi pa nelci ce'u xi re kei kei lu mi na mutce nelci lo tersu'i stura be zo tanru li'u
+</quote>
+
+doi la .xorxes. what are your ideas for unbloating these words? I can see gismu5 and tanru5 getting removed.
+
+There is also the question of what "meaning" means, e.g. valsi2. It has usage as ka, du'u and as concrete. I've seen {ma valsi ti}, and also {lo du'u broda cu smuni zo broda} (and what's the exact difference between {sinxa} and {smuni}), but gismu2 is more clearly ka (a relation). Let's discuss.


### PR DESCRIPTION
This group consists of:
gadri
gismu 
valsi
sumti
cmavo
lujvo
tanru
bridi
gerna
(+ others?)

xorxes recently said:
<quote>
I'm not advocating these by any means, I think grammar words are particularly messy and could do with some unbloating, but this is how I read the current definitions:
zo nelci cu gismu lo ka ce'u ce'u nelci kei lo nelci ce'o lo se nelci zoi ke nel ke jo'u zoi ke nei ke jo'u zoi ke nelcy ke jo'u zoi ke nelci ke

lo'u mutce nelci le'u cu tanru zo mutce zo nelci lo ka ce'u xi pa mutce lo ka ce'u xi pa nelci ce'u xi re kei kei lu mi na mutce nelci lo tersu'i stura be zo tanru li'u
</quote>

doi la .xorxes. what are your ideas for unbloating these words? I can see gismu5 and tanru5 getting removed.

There is also the question of what "meaning" means, e.g. valsi2. It has usage as ka, du'u and as concrete. I've seen {ma valsi ti}, and also {lo du'u broda cu smuni zo broda} (and what's the exact difference between {sinxa} and {smuni}), but gismu2 is more clearly ka (a relation). Let's discuss.
